### PR TITLE
chore(eslint): add max-lines rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,5 +3,10 @@
     "node": true
   },
   "extends": ["eslint:recommended", "plugin:vue/vue3-recommended", "prettier"],
-  "rules": {}
+  "rules": {
+    "max-lines": [
+      "error",
+      { "max": 120, "skipBlankLines": true, "skipComments": true }
+    ]
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,8 +5,8 @@
   "extends": ["eslint:recommended", "plugin:vue/vue3-recommended", "prettier"],
   "rules": {
     "max-lines": [
-      "error",
-      { "max": 120, "skipBlankLines": true, "skipComments": true }
+      "warn",
+      { "max": 100, "skipBlankLines": true, "skipComments": true }
     ]
   }
 }


### PR DESCRIPTION
In order to improve our workflow, I added a rule that limits the maximum of lines of a file to 100 (excluding comments and blank lines). This will make us work with smaller pieces of code and therefore with smaller components that will make our code cleaner and easier to handle and maintain.