### PR TITLE
feat: add custom columns and make possible to add tasks to each of them

### DIFF
--- a/src/components/AddColumnForm.vue
+++ b/src/components/AddColumnForm.vue
@@ -1,52 +1,43 @@
 <template>
-  <div class="form-wrapper bg-slate-400">
+  <div class="form-wrapper">
     <NForm
       ref="formRef"
       inline
       :label-width="80"
       :model="formValue"
       :rules="rules"
-      size="small"
+      size="large"
       @submit="handleSubmit"
     >
-      <n-form-item path="task">
-        <n-input v-model:value="formValue.task" placeholder="Task" />
+      <n-form-item path="column">
+        <n-input v-model:value="formValue.column" placeholder="Column" />
       </n-form-item>
       <n-form-item>
-        <n-button class="bg-white text-black" attr-type="submit">
-          Add
-        </n-button>
+        <n-button attr-type="submit"> Add </n-button>
       </n-form-item>
     </NForm>
   </div>
 </template>
 
 <script setup>
-import { reactive, ref, defineProps } from "vue";
+import { reactive, ref } from "vue";
 import { NForm, NFormItem, NInput, NButton, useMessage } from "naive-ui";
 
 import { useTasksStore } from "../stores/TasksStore";
 
-const { addTask } = useTasksStore();
+const { addColumn } = useTasksStore();
 
 const message = useMessage();
 const formValue = reactive({
-  task: "",
-});
-
-const props = defineProps({
-  index: {
-    type: Number,
-    required: true,
-  },
+  column: "",
 });
 
 const formRef = ref(null);
 
 const rules = {
-  task: {
+  column: {
     required: true,
-    message: "Please enter your task",
+    message: "Please enter your column",
     trigger: ["input"],
   },
 };
@@ -56,20 +47,20 @@ function handleSubmit(e) {
   formRef.value
     ?.validate()
     .then(() => {
-      addTask(props.index, formValue.task);
-      formValue.task = "";
-      message.success("New task added");
+      addColumn(formValue.column);
+      formValue.column = "";
+      message.success("New column added");
     })
     .catch((errors) => {
       console.log(errors);
-      message.error("A task must not be empty");
+      message.error("A column must not be empty");
     });
 }
 </script>
 
 <style scoped>
 .form-wrapper {
-  padding: 0 1rem;
+  padding: 1rem;
   margin: auto;
 }
 </style>

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -1,20 +1,40 @@
 <template>
-  <AddTaskForm />
+  <AddColumnForm />
   <n-scrollbar x-scrollable>
     <div class="columns-wrapper">
-      <div v-for="column in dashboard.columns" :key="column.name">
-        <h3>{{ column.name }}</h3>
+      <div v-for="(column, index) in dashboard.columns" :key="column.name">
+        <div class="flex justify-between pb-4">
+          <span
+            :class="index === 0 ? 'invisible' : 'cursor-pointer text-xl'"
+            @click="moveColumnToLeft(index)"
+            >⬅️</span
+          >
+          <h3>{{ column.name }}</h3>
+          <span
+            :class="
+              index === dashboard.columns.length - 1
+                ? 'invisible'
+                : 'cursor-pointer text-xl'
+            "
+            @click="moveColumnToRight(index)"
+            >➡️</span
+          >
+        </div>
+
         <draggable
-          class="column"
+          class="column bg-slate-300 p-4 w-80"
           :list="column.tasks"
           group="columns"
           item-key="title"
           @change="onChange"
         >
           <template #item="{ element }">
-            <div>{{ element.title }}</div>
+            <div class="cursor-grab bg-white rounded p-2 mb-4">
+              {{ element.title }}
+            </div>
           </template>
         </draggable>
+        <AddTaskForm :index="index" />
       </div>
     </div>
   </n-scrollbar>
@@ -27,8 +47,15 @@ import draggable from "vuedraggable";
 
 import { useTasksStore } from "../stores/TasksStore";
 import AddTaskForm from "./AddTaskForm.vue";
+import AddColumnForm from "./AddColumnForm.vue";
 
-const { loadDashboard, dashboard, updateDashboard } = useTasksStore();
+const {
+  loadDashboard,
+  dashboard,
+  updateDashboard,
+  moveColumnToLeft,
+  moveColumnToRight,
+} = useTasksStore();
 
 function onChange() {
   updateDashboard();
@@ -42,12 +69,11 @@ onMounted(() => {
 <style scoped>
 .columns-wrapper {
   display: flex;
-  gap: 3em;
-  margin: 0 2em;
+  align-items: center;
+  gap: 2em;
+  margin: 0 1em;
 }
 .column {
   min-height: 300px;
-  width: 140px;
-  background-color: #f2f4f5;
 }
 </style>

--- a/src/stores/TasksStore.js
+++ b/src/stores/TasksStore.js
@@ -17,11 +17,10 @@ export const useTasksStore = defineStore("tasks", () => {
     Object.assign(dashboard, data);
   }
 
-  async function addTask(title) {
+  async function addTask(columnIndex, title) {
     const task = { title };
 
-    //FIXME: is this OK? Should we allow to add task to any column?
-    dashboard.columns[0].tasks.push(task);
+    dashboard.columns[columnIndex].tasks.push(task);
 
     await updateDashboard();
   }
@@ -34,10 +33,39 @@ export const useTasksStore = defineStore("tasks", () => {
     if (error) throw error;
   }
 
+  async function addColumn(columnName) {
+    const column = { name: columnName, tasks: [] };
+
+    dashboard.columns.push(column);
+
+    await updateDashboard();
+  }
+
+  async function moveColumnToLeft(index) {
+    let columnsArray = dashboard.columns;
+    let aux = columnsArray[index - 1];
+    columnsArray[index - 1] = columnsArray[index];
+    columnsArray[index] = aux;
+
+    await updateDashboard();
+  }
+
+  async function moveColumnToRight(index) {
+    let columnsArray = dashboard.columns;
+    let aux = columnsArray[index + 1];
+    columnsArray[index + 1] = columnsArray[index];
+    columnsArray[index] = aux;
+
+    await updateDashboard();
+  }
+
   return {
     loadDashboard,
     dashboard,
     addTask,
+    addColumn,
     updateDashboard,
+    moveColumnToLeft,
+    moveColumnToRight,
   };
 });


### PR DESCRIPTION
I created an input to add custom columns to the dashboard. All the columns can be moved using the arrows next to their name. The users are also able to add a task in whichever column they like. The cursor changes when hovering the arrows and the draggable tasks. All the data persists thanks to Supabase.

Fixes: #27 