### PR TITLE
feat: add prompt confirmation to delete columns and tasks

### DIFF
--- a/src/components/BoardColumn/AddTaskForm.vue
+++ b/src/components/BoardColumn/AddTaskForm.vue
@@ -14,22 +14,17 @@
         <n-input v-model:value="formValue.task" placeholder="Task" />
       </n-form-item>
       <n-form-item>
-        <n-button
-          :disabled="!isValid"
-          type="primary"
-          class="bg-white text-black"
-          attr-type="submit"
-        >
+        <n-button type="primary" :disabled="!isValid" attr-type="submit">
           Add
         </n-button>
       </n-form-item>
       <n-form-item>
-        <n-button
-          type="error"
-          title="Delete column"
-          @click="removeColumn(index)"
-          >🗑️</n-button
-        >
+        <n-popconfirm @positive-click="handlePositiveClick(index)">
+          <template #trigger>
+            <n-button type="error" title="Delete column">🗑️</n-button>
+          </template>
+          Do you want to delete this column?
+        </n-popconfirm>
       </n-form-item>
     </NForm>
   </div>
@@ -37,7 +32,14 @@
 
 <script setup>
 import { reactive, ref, defineProps } from "vue";
-import { NForm, NFormItem, NInput, NButton, useMessage } from "naive-ui";
+import {
+  NForm,
+  NFormItem,
+  NInput,
+  NButton,
+  useMessage,
+  NPopconfirm,
+} from "naive-ui";
 
 import { useTasksStore } from "../../stores/TasksStore";
 
@@ -70,7 +72,7 @@ const rules = {
       isValid.value = true;
       return true;
     },
-    trigger: ["input"],
+    trigger: ["blur"],
   },
 };
 
@@ -87,6 +89,11 @@ function handleSubmit(e) {
       console.log(errors);
       message.error("A task must not be empty");
     });
+}
+
+function handlePositiveClick(index) {
+  removeColumn(index);
+  message.success("Column deleted successfully.");
 }
 </script>
 

--- a/src/components/BoardColumn/TaskCard.vue
+++ b/src/components/BoardColumn/TaskCard.vue
@@ -4,7 +4,12 @@
       <p>{{ task.title }}</p>
       <div class="flex gap-2">
         <button @click="showModal = true">✏</button>
-        <button @click="removeTask(columnIndex, index)">🧹</button>
+        <n-popconfirm @positive-click="handlePositiveClick(columnIndex, index)">
+          <template #trigger>
+            <button>🧹</button>
+          </template>
+          Do you want to delete this task?
+        </n-popconfirm>
       </div>
     </div>
     <n-modal v-model:show="showModal">
@@ -58,6 +63,7 @@ import {
   NInput,
   NButton,
   useMessage,
+  NPopconfirm,
 } from "naive-ui";
 
 import { useTasksStore } from "../../stores/TasksStore";
@@ -99,5 +105,10 @@ function handleSubmit() {
       console.log(errors);
       message.error("A task must not be empty");
     });
+}
+
+function handlePositiveClick(columnIndex, index) {
+  removeTask(columnIndex, index);
+  message.success("Task deleted successfully.");
 }
 </script>


### PR DESCRIPTION
When the users click the delete buttons for tasks and columns, they get a prompt asking if they are sure to delete the item.