### PR TITLE
fix: validate tasks when editing and remove console.logs

### DIFF
--- a/src/components/AddColumnForm.vue
+++ b/src/components/AddColumnForm.vue
@@ -78,8 +78,7 @@ function handleSubmit(e) {
         showModal.value = false;
       }
     })
-    .catch((errors) => {
-      console.log(errors);
+    .catch(() => {
       message.error("A column must not be empty");
     });
 }

--- a/src/components/BoardColumn/AddTaskForm.vue
+++ b/src/components/BoardColumn/AddTaskForm.vue
@@ -65,7 +65,7 @@ const rules = {
   task: {
     required: true,
     validator(rule, value) {
-      if (!value || value.length <= 3) {
+      if (!value || value.length < 3) {
         isValid.value = false;
         return new Error("A task must have more than 3 letters.");
       }
@@ -85,8 +85,7 @@ function handleSubmit(e) {
       formValue.task = "";
       message.success("New task added");
     })
-    .catch((errors) => {
-      console.log(errors);
+    .catch(() => {
       message.error("A task must not be empty");
     });
 }

--- a/src/components/BoardColumn/TaskCard.vue
+++ b/src/components/BoardColumn/TaskCard.vue
@@ -32,11 +32,7 @@
           </n-form-item>
           <n-form-item>
             <div class="flex gap-2">
-              <n-button
-                class="bg-white text-black"
-                type="primary"
-                attr-type="submit"
-              >
+              <n-button :disabled="!isValid" type="primary" attr-type="submit">
                 Save
               </n-button>
               <n-button
@@ -70,6 +66,8 @@ import { useTasksStore } from "../../stores/TasksStore";
 
 const { removeTask, editTask } = useTasksStore();
 
+const isValid = ref(false);
+
 const props = defineProps({
   index: { type: Number, required: true },
   task: { type: Object, required: true },
@@ -88,8 +86,15 @@ const formRef = ref(null);
 const rules = {
   task: {
     required: true,
-    message: "Please enter your task",
-    trigger: ["input"],
+    validator(rule, value) {
+      if (!value || value.length < 3) {
+        isValid.value = false;
+        return new Error("A task must have more than 3 letters.");
+      }
+      isValid.value = true;
+      return true;
+    },
+    trigger: ["blur"],
   },
 };
 
@@ -101,8 +106,7 @@ function handleSubmit() {
       editTask(props.columnIndex, props.index, formValue.task);
       message.success("Save edited task");
     })
-    .catch((errors) => {
-      console.log(errors);
+    .catch(() => {
       message.error("A task must not be empty");
     });
 }

--- a/src/pages/PasswordRecovery.vue
+++ b/src/pages/PasswordRecovery.vue
@@ -91,8 +91,7 @@ function handleSubmit(e) {
       isSubmitted.value = true;
       loadingBar.finish();
     })
-    .catch((error) => {
-      console.log(error);
+    .catch(() => {
       message.error("Please enter your email");
     });
 }

--- a/src/pages/SignIn.vue
+++ b/src/pages/SignIn.vue
@@ -94,8 +94,7 @@ function handleSubmit(e) {
       await signIn(formValue.email, formValue.password);
       router.push({ name: "dashboard" });
     })
-    .catch((error) => {
-      console.log(error);
+    .catch(() => {
       message.error("Please enter your email and a password");
     });
 }


### PR DESCRIPTION
When the user edits a task, there's a validator that checks that the task is at least 3 characters long. I also removed the console.logs.