### PR TITLE
feat: redirect user to dashboard when logged in and visiting auth pages

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -53,6 +53,14 @@ router.beforeEach(async (to) => {
   if (!user && to.name === "dashboard") {
     return { name: "login" };
   }
+  if (
+    (user && to.name === "register") ||
+    (user && to.name === "login") ||
+    (user && to.name === "change-password") ||
+    (user && to.name === "forgot-password")
+  ) {
+    return { name: "dashboard" };
+  }
 });
 
 export default router;


### PR DESCRIPTION
The users are no longer able to visit the Auth pages (register, login, change password and forgot password) when they're logged in. Instead, they are redirected to their dashboard.