### PR TITLE
fix: make add task input not expand when validations warning shows

### DIFF
--- a/src/components/BoardColumn/AddTaskForm.vue
+++ b/src/components/BoardColumn/AddTaskForm.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="form-wrapper bg-slate-400 rounded-br-lg rounded-bl-lg">
+  <div
+    class="bg-slate-400 rounded-br-lg rounded-bl-lg m-auto px-4 pb-24 relative"
+  >
     <NForm
       ref="formRef"
       inline
@@ -7,10 +9,10 @@
       :model="formValue"
       :rules="rules"
       size="small"
-      class=""
+      class="absolute"
       @submit="handleSubmit"
     >
-      <n-form-item path="task">
+      <n-form-item path="task" class="max-w-[150px]">
         <n-input v-model:value="formValue.task" placeholder="Task" />
       </n-form-item>
       <n-form-item>
@@ -72,7 +74,7 @@ const rules = {
       isValid.value = true;
       return true;
     },
-    trigger: ["blur"],
+    trigger: ["input"],
   },
 };
 
@@ -95,10 +97,3 @@ function handlePositiveClick(index) {
   message.success("Column deleted successfully.");
 }
 </script>
-
-<style scoped>
-.form-wrapper {
-  padding: 0 1rem;
-  margin: auto;
-}
-</style>

--- a/src/components/BoardColumn/TaskCard.vue
+++ b/src/components/BoardColumn/TaskCard.vue
@@ -94,7 +94,7 @@ const rules = {
       isValid.value = true;
       return true;
     },
-    trigger: ["blur"],
+    trigger: ["input"],
   },
 };
 

--- a/src/helpers/form-rules.js
+++ b/src/helpers/form-rules.js
@@ -7,7 +7,7 @@ export const email = {
 
     return true;
   },
-  trigger: ["blur"],
+  trigger: ["input"],
 };
 
 export const password = {
@@ -19,5 +19,5 @@ export const password = {
 
     return true;
   },
-  trigger: ["blur"],
+  trigger: ["input"],
 };

--- a/src/pages/ChangePassword.vue
+++ b/src/pages/ChangePassword.vue
@@ -72,7 +72,7 @@ const rules = {
 
       return true;
     },
-    trigger: ["blur"],
+    trigger: ["input"],
   },
 };
 

--- a/src/pages/SignUp.vue
+++ b/src/pages/SignUp.vue
@@ -118,7 +118,7 @@ const rules = {
 
       return true;
     },
-    trigger: ["blur"],
+    trigger: ["input"],
   },
   terms: {
     validator(rule, value) {


### PR DESCRIPTION
The task input box was expanding when the warning of the validator showed. Now it's solved 🎉 